### PR TITLE
fix shallow copy of reflection causing thread safety issues seen in #260

### DIFF
--- a/lib/polyamorous/join_association.rb
+++ b/lib/polyamorous/join_association.rb
@@ -29,12 +29,11 @@ module Polyamorous
     end
 
     def swapping_reflection_klass(reflection, klass)
-      reflection = reflection.clone
-      original_polymorphic = reflection.options.delete(:polymorphic)
-      reflection.instance_variable_set(:@klass, klass)
-      yield reflection
-    ensure
-      reflection.options[:polymorphic] = original_polymorphic
+      new_reflection = reflection.clone
+      new_reflection.instance_variable_set(:@options, reflection.options.clone)
+      new_reflection.options.delete(:polymorphic)
+      new_reflection.instance_variable_set(:@klass, klass)
+      yield new_reflection
     end
 
     def equality_with_polymorphism(other)

--- a/spec/polyamorous/join_association_spec.rb
+++ b/spec/polyamorous/join_association_spec.rb
@@ -5,6 +5,7 @@ module Polyamorous
     let(:join_dependency) { new_join_dependency Note, {} }
     let(:parent) { join_dependency.join_base }
     let(:reflection) { Note.reflect_on_association(:notable) }
+    let(:join_association) { JoinAssociation.new(reflection, join_dependency, parent, Article) }
     subject {
       join_dependency.build_join_association_respecting_polymorphism(
         reflection, parent, Person
@@ -22,6 +23,15 @@ module Polyamorous
           reflection, parent, Article
         )
       )
+    end
+
+    it 'leaves the orginal reflection intact for thread safety' do
+      reflection.instance_variable_set(:@klass, Article)
+      join_association.swapping_reflection_klass(reflection, Person) do |new_reflection|
+        new_reflection.options.object_id.should_not eq(reflection.options.object_id)
+        new_reflection.klass.should == Person
+        reflection.klass.should == Article
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes the thread safety issues seen in https://github.com/ernie/squeel/issues/260

`reflection = reflection.clone` does not clone the options hash, causing some scenarios where the original `reflection` option is no longer set as polymorphic.

Because the original options hash is no longer modified, we can safely remove the ensure block.
