### PR TITLE
Move something in JoinDependency and JoinAssociation from squeel to polyamorous

### DIFF
--- a/lib/polyamorous/activerecord_4.1/join_association.rb
+++ b/lib/polyamorous/activerecord_4.1/join_association.rb
@@ -2,6 +2,7 @@ module Polyamorous
   module JoinAssociationExtensions
     def self.included(base)
       base.class_eval do
+        attr_reader :join_type
         alias_method_chain :initialize, :polymorphism
         if base.method_defined?(:active_record)
           alias_method :base_klass, :active_record
@@ -15,7 +16,8 @@ module Polyamorous
       end
     end
 
-    def initialize_with_polymorphism(reflection, children, polymorphic_class = nil)
+    def initialize_with_polymorphism(reflection, children, polymorphic_class = nil, join_type = Arel::Nodes::InnerJoin)
+      @join_type = join_type
       if polymorphic_class && ::ActiveRecord::Base > polymorphic_class
         swapping_reflection_klass(reflection, polymorphic_class) do |reflection|
           initialize_without_polymorphism(reflection, children)

--- a/lib/polyamorous/activerecord_4.1/join_dependency.rb
+++ b/lib/polyamorous/activerecord_4.1/join_dependency.rb
@@ -22,9 +22,9 @@ module Polyamorous
           reflection.check_validity!
 
           if reflection.options[:polymorphic]
-            JoinAssociation.new reflection, build(right, name.klass || base_klass), name.klass
+            JoinAssociation.new reflection, build(right, name.klass || base_klass), name.klass, name.type
           else
-            JoinAssociation.new reflection, build(right, reflection.klass), name.klass
+            JoinAssociation.new reflection, build(right, reflection.klass), name.klass, name.type
           end
         else
           reflection = find_reflection base_klass, name


### PR DESCRIPTION
Hi @ernie,

I have moved code which combined Polyamorous tightly in Squeel here. 

Includes:
1. All contents in `squeel/adapters/active_record/4.1(4.2)/join_association_extensions.rb`
2. `build_with_squeel` method in `squeel/adapters/active_record/4.1(4.2)/join_dependency_extensions.rb`

`walk_tree` uses classes of `Squeel::Nodes` , so I think it shouldn't be moved here.
I'm not sure about `join_constraints` method.

Would you please have a look? If there are more things need to be moved, just tell me. After this patch is merged, I will remove relative code in Squeel immediately. Thank you very much.
