### PR TITLE
Move all remaining join dependency stuff from squeel.

### DIFF
--- a/lib/polyamorous.rb
+++ b/lib/polyamorous.rb
@@ -21,9 +21,13 @@ if defined?(::ActiveRecord)
     end
   end
 
+  require 'polyamorous/tree_node'
   require 'polyamorous/join'
 
-  if ActiveRecord::VERSION::STRING >= "4.1"
+  if ActiveRecord::VERSION::STRING >= "4.2"
+    require 'polyamorous/activerecord_4.1/join_association'
+    require 'polyamorous/activerecord_4.2/join_dependency'
+  elsif ActiveRecord::VERSION::STRING >= "4.1"
     require 'polyamorous/activerecord_4.1/join_association'
     require 'polyamorous/activerecord_4.1/join_dependency'
   else

--- a/lib/polyamorous/activerecord_4.2/join_dependency.rb
+++ b/lib/polyamorous/activerecord_4.2/join_dependency.rb
@@ -1,0 +1,12 @@
+require 'polyamorous/activerecord_4.1/join_dependency'
+
+module Polyamorous
+  module JoinDependencyExtensions
+    def make_joins(parent, child)
+      tables    = child.tables
+      info      = make_constraints parent, child, tables, child.join_type || Arel::Nodes::InnerJoin
+
+      [info] + child.children.flat_map { |c| make_joins(child, c) }
+    end
+  end
+end

--- a/lib/polyamorous/join.rb
+++ b/lib/polyamorous/join.rb
@@ -1,5 +1,7 @@
 module Polyamorous
   class Join
+    include TreeNode
+
     attr_accessor :name
     attr_reader :type, :klass
 
@@ -29,6 +31,10 @@ module Polyamorous
     end
 
     alias :== :eql?
+
+    def add_to_tree(hash)
+      hash[self] ||= {}
+    end
 
     private
 

--- a/lib/polyamorous/tree_node.rb
+++ b/lib/polyamorous/tree_node.rb
@@ -1,0 +1,7 @@
+module Polyamorous
+  module TreeNode
+    def add_to_tree(hash)
+      raise NotImplementedError
+    end
+  end
+end

--- a/spec/polyamorous/join_spec.rb
+++ b/spec/polyamorous/join_spec.rb
@@ -2,5 +2,18 @@ require 'spec_helper'
 
 module Polyamorous
   describe Join do
+    it "is a tree node" do
+      join = new_join(:articles, :outer)
+      expect(join).to be_kind_of(TreeNode)
+    end
+
+    it "can be add to a tree" do
+      join = new_join(:articles, :outer)
+
+      tree_hash = {}
+      join.add_to_tree(tree_hash)
+
+      expect(tree_hash[join]).to be {}
+    end
   end
 end


### PR DESCRIPTION
Try to add a `TreeNode` module to abstract all behaviors in the `walk_tree` method. So we can drop all join dependency stuff in Squeel.

I'm not sure that it's the best way to do it.
