### PR TITLE
Update travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,71 +1,49 @@
 language: ruby
 
 sudo: false
+cache: bundler
 
 before_install:
   - travis_retry gem install bundler
 
 rvm:
-  - 2.3.1
-  - 2.2.5
-  - 2.1.10
-  - 2.0
-  - 1.9
+  - 2.4.2
+  - 2.3.5
+  - 2.2.8
 
 env:
   - RAILS=4-2-stable AREL=6-0-stable DB=sqlite
   - RAILS=4-2-stable AREL=6-0-stable DB=mysql
   - RAILS=4-2-stable AREL=6-0-stable DB=postgres
-
-  - RAILS=4-1-stable AREL=5-0-stable DB=sqlite
-  - RAILS=4-1-stable AREL=5-0-stable DB=mysql
-  - RAILS=4-1-stable AREL=5-0-stable DB=postgres
-
-  - RAILS=4-0-stable AREL=4-0-stable DB=sqlite
-  - RAILS=4-0-stable AREL=4-0-stable DB=mysql
-  - RAILS=4-0-stable AREL=4-0-stable DB=postgres
-
-  - RAILS=3-2-stable AREL=3-0-stable DB=sqlite
-  - RAILS=3-2-stable AREL=3-0-stable DB=mysql
-  - RAILS=3-2-stable AREL=3-0-stable DB=postgres
-
-  - RAILS=3-1-stable AREL=2-2-stable DB=sqlite
-  - RAILS=3-1-stable AREL=2-2-stable DB=mysql
-  - RAILS=3-1-stable AREL=2-2-stable DB=postgres
-
-  - RAILS=3-0-stable AREL=2-0-stable DB=sqlite
-  - RAILS=3-0-stable AREL=2-0-stable DB=mysql
-  - RAILS=3-0-stable AREL=2-0-stable DB=postgres
+  - RAILS=5-0-stable AREL=7-0-stable DB=sqlite
+  - RAILS=5-0-stable AREL=7-0-stable DB=mysql
+  - RAILS=5-0-stable AREL=7-0-stable DB=postgres
+  - RAILS=5-1-stable AREL=8-0-stable DB=sqlite
+  - RAILS=5-1-stable AREL=8-0-stable DB=mysql
+  - RAILS=5-1-stable AREL=8-0-stable DB=postgres
 
 matrix:
   include:
-    - rvm: 2.3.1
+    - rvm: 2.4.2
       env: RAILS=master DB=sqlite3
-    - rvm: 2.3.1
+    - rvm: 2.4.2
       env: RAILS=master DB=mysql
-    - rvm: 2.3.1
+    - rvm: 2.4.2
       env: RAILS=master DB=postgres
 
-    - rvm: 2.2.5
+    - rvm: 2.3.5
       env: RAILS=master DB=sqlite3
-    - rvm: 2.2.5
+    - rvm: 2.3.5
       env: RAILS=master DB=mysql
-    - rvm: 2.2.5
+    - rvm: 2.3.5
       env: RAILS=master DB=postgres
 
-    - rvm: 2.3.1
-      env: RAILS=5-0-stable DB=sqlite3
-    - rvm: 2.3.1
-      env: RAILS=5-0-stable DB=mysql
-    - rvm: 2.3.1
-      env: RAILS=5-0-stable DB=postgres
-
-    - rvm: 2.2.5
-      env: RAILS=5-0-stable DB=sqlite3
-    - rvm: 2.2.5
-      env: RAILS=5-0-stable DB=mysql
-    - rvm: 2.2.5
-      env: RAILS=5-0-stable DB=postgres
+    - rvm: 2.2.8
+      env: RAILS=master DB=sqlite3
+    - rvm: 2.2.8
+      env: RAILS=master DB=mysql
+    - rvm: 2.2.8
+      env: RAILS=master DB=postgres
 
   allow_failures:
     - env: RAILS=master DB=sqlite3

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Polyamorous
-
-[![Build Status](https://travis-ci.org/activerecord-hackery/polyamorous.svg)]
-(https://travis-ci.org/activerecord-hackery/polyamorous)
-[![Gem Version](https://badge.fury.io/rb/polyamorous.svg)]
-(http://badge.fury.io/rb/polyamorous)
-[![Code Climate](https://codeclimate.com/github/activerecord-hackery/polyamorous/badges/gpa.svg)]
-(https://codeclimate.com/github/activerecord-hackery/polyamorous)
+[![Build Status](https://travis-ci.org/activerecord-hackery/polyamorous.svg?branch=master)](https://travis-ci.org/activerecord-hackery/polyamorous)
+[![Gem Version](https://badge.fury.io/rb/polyamorous.svg)](https://badge.fury.io/rb/polyamorous)
+[![Code Climate](https://codeclimate.com/github/activerecord-hackery/polyamorous/badges/gpa.svg)](https://codeclimate.com/github/activerecord-hackery/polyamorous)
 
 Polyamorous is an extraction of shared code from the
 [Active Record Hackery](https://github.com/activerecord-hackery) gems


### PR DESCRIPTION
Drop support for unsopported ruby and rails versions
Add tests for 5.1

Currently only ruby >= 2.2 has support
Currently only rails >=4.2 has support

Fix README badges

Initial PR to start working on dropping support for old ruby/rails and add support for rails 5.2