### PR TITLE
`make_constraints` returns an array in rails 5.2, so remove unnecessary coercing

### DIFF
--- a/lib/polyamorous/activerecord_5.2_ruby_2/join_dependency.rb
+++ b/lib/polyamorous/activerecord_5.2_ruby_2/join_dependency.rb
@@ -84,7 +84,7 @@ module Polyamorous
       join_type = Arel::Nodes::OuterJoin
       info      = make_constraints parent, child, tables, join_type
 
-      [info] + child.children.flat_map { |c|
+      info + child.children.flat_map { |c|
         make_polyamorous_left_outer_joins(child, c)
       }
     end
@@ -96,7 +96,7 @@ module Polyamorous
       join_type = child.join_type || Arel::Nodes::InnerJoin
       info      = make_constraints parent, child, tables, join_type
 
-      [info] + child.children.flat_map { |c|
+      info + child.children.flat_map { |c|
         make_polyamorous_inner_joins(child, c)
       }
     end


### PR DESCRIPTION
In rails 5.2 (beta), `ActiveRecod::Associations#make_constraints` is returning an Array where previously it did not. This is causing issues with polyamorous, as both `make_polyamorous_inner_joins` and `make_polyamorous_left_outer_joins` were expected to return an array but are now returning an array of arrays.