### PR TITLE
fix: the number of arguments of join_constraints

### DIFF
--- a/lib/polyamorous/activerecord_5.2_ruby_2/join_dependency.rb
+++ b/lib/polyamorous/activerecord_5.2_ruby_2/join_dependency.rb
@@ -55,7 +55,9 @@ module Polyamorous
     # left_outer_joins (see #make_polyamorous_left_outer_joins below) and added
     # passing an additional argument, `join_type`, to #join_constraints.
     #
-    def join_constraints(outer_joins, join_type)
+    def join_constraints(outer_joins, join_type, alias_tracker = nil)
+      @alias_tracker = alias_tracker
+
       joins = join_root.children.flat_map { |child|
         if join_type == Arel::Nodes::OuterJoin
           make_polyamorous_left_outer_joins join_root, child


### PR DESCRIPTION
The latest activerecord's(`5.2.1`) `ActiveRecord::Associations::ClassMethods::JoinDependency#join_constraints` has 3 arguments.
So, I change the  `join_constraints` inserted by this gem to 3 arguments.

c.f)
https://github.com/rails/rails/commit/50036e673b3b6ff41476814b212b55fabac3a638 : `activerecord/lib/active_record/associations/join_dependency.rb` l.79